### PR TITLE
Added cleanup script to remove the AMI and snapshot associated with it

### DIFF
--- a/packer-aws-shell/cleanup.sh
+++ b/packer-aws-shell/cleanup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+ami_id=$(cat output.json | jq '.builds[] | .artifact_id' | cut -f2 -d: | tr -d '"')
+echo "Finding the snapshots associated for ${ami_id}"
+
+snapshot_ids=$(aws ec2 describe-images --image-id $ami_id --query 'Images[*].BlockDeviceMappings[*].Ebs.SnapshotId' --output text)
+
+echo -e "Snapshots associated with the AMI ${ami_id}\n${snapshot_ids}"
+
+echo "Deregistering the AMI ${ami_id}"
+
+aws ec2 deregister-image --image-id ${ami_id}
+
+echo "Removed AMI ${ami_id}"
+
+for snapshot_id in $snapshot_ids; do
+    aws ec2 delete-snapshot --snapshot-id $snapshot_id
+    echo "Removed snapshot ${snapshot_id}"
+done

--- a/packer-aws-shell/vm.pkr.hcl
+++ b/packer-aws-shell/vm.pkr.hcl
@@ -30,4 +30,8 @@ build {
   post-processor "shell-local" {
     inline = ["echo foo"]
   }
+
+  post-processor "manifest" {
+    output = "output.json"
+  }
 }


### PR DESCRIPTION
This cleanup script is useful to clean up the AWS resources like AMIs and Snapshots associated with AMIs after trying out packer to save some costs associated with storing AMIs and Snapshots.
Its ideal to save the output using the "manifest" post processor provisioner.

```HCL
post-processor "manifest" {
        output = "output.json"
}
```